### PR TITLE
docs: add canonical API reference and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A canvas-based network/graph visualization library with React and vanilla JS support. Render interactive node-edge graphs on layered HTML5 canvases with pan, zoom, drag, hover, and shape editing — with zero runtime dependencies.
 
+**[Documentation & live examples →](https://netiplot.coda-fi.com/)**
+
 ## Install
 
 ```bash
@@ -9,28 +11,6 @@ npm install @jonmodell/netiplot
 ```
 
 ## Usage
-
-### Vanilla JS
-
-```ts
-import { NetiPlot } from '@jonmodell/netiplot/vanilla';
-import type { NetiPlotGraph } from '@jonmodell/netiplot';
-
-const graph: NetiPlotGraph = {
-  nodes: [{ id: 'a', label: 'Node A' }, { id: 'b', label: 'Node B' }],
-  edges: [{ id: 'e1', from: 'a', to: 'b' }],
-};
-
-const net = new NetiPlot(document.getElementById('container')!, {
-  graph,
-  onMouse: (type, item) => console.log(type, item),
-});
-
-// Update the graph at any time:
-net.setGraph(updatedGraph);
-net.zoom('all');
-net.destroy();
-```
 
 ### React
 
@@ -44,182 +24,52 @@ const graph: NetiPlotGraph = {
 };
 
 export default function App() {
-  return <NetiPlotReact graph={graph} />;
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '600px', overflow: 'hidden' }}>
+      <NetiPlotReact graph={graph} />
+    </div>
+  );
 }
 ```
 
-## React Props
-
-| Prop | Type | Description |
-|------|------|-------------|
-| `graph` | `NetiPlotGraph` | Required. `{ nodes: NetiPlotNodeDefinition[], edges: NetiPlotEdgeDefinition[] }` |
-| `shapes` | `NetiPlotShapeDefinition[]` | Background shapes rendered below the graph |
-| `options` | `NetiPlotOptions` | Configuration for nodes, edges, camera, layout, hover, and interaction |
-| `images` | `NetiPlotImageMap` | Map of image IDs to image elements for node icons |
-| `layouter` | `NetiPlotLayouter` | Custom layout function (e.g. d3-force, dagre). Defaults to hierarchical. |
-| `shouldRunLayouter` | `ShouldRunLayouter` | Predicate controlling when the layouter re-runs on data changes |
-| `nodeDrawingFunction` | `NodeDrawingFunction` | Custom canvas drawing function for nodes |
-| `shapeDrawingFunction` | `ShapeDrawingFunction` | Custom canvas drawing function for shapes |
-| `onMouse` | `NetiPlotMouseHandler` | Mouse event callback |
-| `callbackFn` | `(data: NetiPlotCallbackData) => void` | Provides programmatic access to the network (positions, camera, fit) |
-| `customControls` | `(data: CustomControlsData) => ReactNode \| null` | Replace or hide the built-in zoom controls |
-| `className` | `string` | CSS class for the container |
-| `identifier` | `string` | Unique ID for the instance |
-
-## Nodes
-
-At minimum, nodes require a unique `id`. Supported properties:
+### Vanilla JS
 
 ```ts
-{
-  id: string;          // required
-  label?: string;      // text label rendered with the node
-  innerLabel?: string; // label inside the node shape
-  image?: string;      // key into the `images` prop map
-  shape?: string;      // passed to nodeDrawingFunction
-  size?: number;
-  fixed?: boolean;     // exclude from layout
-  x?: number;          // manual position
-  y?: number;
-  style?: {
-    background?: string;
-    border?: string;
-    size?: number;
-  };
-}
-```
+import { NetiPlot } from '@jonmodell/netiplot/vanilla';
+import type { NetiPlotGraph } from '@jonmodell/netiplot';
 
-Custom properties can be added freely and accessed in a `nodeDrawingFunction`.
-
-## Edges
-
-```ts
-{
-  id: string;      // required
-  from: string;    // source node id
-  to: string;      // target node id
-  label?: string;
-  size?: number;
-  style?: {
-    color?: string;
-    lineWidth?: number;
-    font?: string;
-    fontColor?: string;
-  };
-}
-```
-
-## Shapes
-
-Background shapes rendered on the lowest canvas layer, useful for grouping or annotating regions of the graph.
-
-```ts
-{
-  shape: string;   // required
-  x: number;       // required
-  y: number;       // required
-  width?: number;
-  height?: number;
-  size?: number;
-  visible?: boolean;
-  noEdit?: boolean;
-  noClick?: boolean;
-  style?: {
-    background?: string;
-    border?: string;
-    lineWidth?: number;
-  };
-}
-```
-
-## Mouse Events
-
-The `onMouse` callback receives all interaction events:
-
-```ts
-onMouse={(type, item, event) => {
-  // type: 'nodeClick' | 'nodeDblClick' | 'nodesDragged' |
-  //       'edgeClick' | 'edgeDblClick' |
-  //       'shapeClick' | 'shapeDblClick' | 'shapeUpdate' |
-  //       'backgroundClick'
-}}
-```
-
-## Hover Tooltip
-
-### React — pass a renderer via `options.hover`:
-
-```tsx
-options={{
-  hover: {
-    nodeRenderer: (node) => <div>{node.label}</div>,
-    edgeRenderer: (edge) => <div>{edge.label}</div>,
-    delay: 300,
-    width: 200,
-    height: 100,
-  }
-}}
-```
-
-### Vanilla — use the `hover` config (returns `HTMLElement | string`):
-
-```ts
-new NetiPlot(el, {
-  graph,
-  hover: {
-    nodeRenderer: (node) => `<b>${node.label}</b>`,
-    delay: 300,
-  },
-});
-```
-
-## Images / Node Icons
-
-```ts
-const images = {
-  server: { element: imgElement, scale: 0.5, offsetX: 0, offsetY: 0 },
+const graph: NetiPlotGraph = {
+  nodes: [{ id: 'a', label: 'Node A' }, { id: 'b', label: 'Node B' }],
+  edges: [{ id: 'e1', from: 'a', to: 'b' }],
 };
 
-// reference by key on any node:
-{ id: 'n1', image: 'server' }
+const net = new NetiPlot(document.getElementById('container')!, { graph });
+
+net.setGraph(updatedGraph);
+net.zoom('all');
+net.destroy();
 ```
 
-## Custom Layout
+The container must have an explicit width and height. No stylesheet import is needed — styles are injected automatically.
 
-```ts
-import type { NetiPlotLayouter } from '@jonmodell/netiplot';
+## Documentation
 
-const myLayouter: NetiPlotLayouter = (data, options, screen, onStopped) => {
-  const { nodeMap } = data;
-  // position nodes by setting node.destination = { x, y }
-  onStopped?.();
-};
-```
+Full documentation, API reference, and interactive examples are at **[netiplot.coda-fi.com](https://netiplot.coda-fi.com/)**.
 
-Return an object with a `stop()` method for async layouts (e.g. force simulations).
+Markdown reference docs are also available in [`docs/`](./docs/) for offline use and LLM context:
 
-## Options
-
-```ts
-options={{
-  nodes: {
-    showLabels: true,
-    defaultSize: 30,
-  },
-  edges: {
-    showLabels: false,
-    arrowheads: true,
-    lineStyle: 'curved', // 'curved' | 'straight'
-  },
-  layoutOptions: {
-    fitOnUpdate: true,
-  },
-  interaction: {
-    allowGraphInteraction: true,
-    allowShapeInteraction: false,
-  },
-}}
-```
+- [`docs/installation.md`](./docs/installation.md) — container setup, entry points
+- [`docs/react.md`](./docs/react.md) — React component quickstart
+- [`docs/vanilla.md`](./docs/vanilla.md) — Vanilla JS class API
+- [`docs/api/props.md`](./docs/api/props.md) — `NetiPlotReact` props reference
+- [`docs/api/options.md`](./docs/api/options.md) — `NetiPlotOptions` structure
+- [`docs/api/graph.md`](./docs/api/graph.md) — node and edge definitions
+- [`docs/api/events.md`](./docs/api/events.md) — mouse events
+- [`docs/api/callback.md`](./docs/api/callback.md) — programmatic access
+- [`docs/custom-drawing.md`](./docs/custom-drawing.md) — custom node/shape drawing
+- [`docs/custom-layouts.md`](./docs/custom-layouts.md) — custom layout algorithms
+- [`docs/shapes.md`](./docs/shapes.md) — background shapes
+- [`docs/images.md`](./docs/images.md) — images and node icons
 
 ## Development
 
@@ -230,3 +80,7 @@ npm run dev:react    # React/Next.js demo (demo-react/)
 npm test
 npm run build        # builds lib/ (React + vanilla entry points)
 ```
+
+## License
+
+MIT

--- a/docs/api/callback.md
+++ b/docs/api/callback.md
@@ -1,0 +1,52 @@
+# Programmatic Access — `callbackFn`
+
+The `callbackFn` prop provides imperative access to the network after it mounts.
+
+```ts
+<NetiPlotReact
+  graph={graph}
+  callbackFn={({ fit, getCamera, getPositions }) => {
+    fit()            // zoom to fit all nodes
+    getCamera()      // → PanScaleState
+    getPositions()   // → Record<id, { x, y }>
+  }}
+/>
+```
+
+## `NetiPlotCallbackData`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fit` | `() => boolean` | Zoom to fit all nodes into view |
+| `getCamera` | `() => PanScaleState` | Current pan and scale state |
+| `getPositions` | `() => Record<string, { x: number; y: number }>` | Current node positions by ID |
+| `getNodePositions` | `(nodes: Map<string, NetiPlotNode>) => Record<string, { x, y }>` | Positions from a given node map |
+| `nodes` | `React.RefObject<Map<string, NetiPlotNode>>` | Ref to the live node map |
+
+## Storing the callback ref
+
+A common pattern is to store the callback data in a ref so you can call it later:
+
+```tsx
+const netRef = useRef<NetiPlotCallbackData | null>(null)
+
+<NetiPlotReact
+  graph={graph}
+  callbackFn={(data) => { netRef.current = data }}
+/>
+
+// Elsewhere:
+<button onClick={() => netRef.current?.fit()}>Fit all</button>
+```
+
+## `PanScaleState`
+
+```ts
+type PanScaleState = {
+  pan: { x: number; y: number }
+  scale: number
+  destinationPan: { x: number; y: number } | null
+  destinationScale: number | null
+  panPerFrame: { x: number; y: number } | null
+}
+```

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,0 +1,63 @@
+# Mouse Events
+
+Handle user interactions via the `onMouse` prop.
+
+```ts
+<NetiPlotReact
+  graph={graph}
+  onMouse={(type, item, event) => {
+    console.log(type, item)
+  }}
+/>
+```
+
+## Callback signature — `NetiPlotMouseHandler`
+
+```ts
+type NetiPlotMouseHandler = (
+  type: NetiPlotMouseEventType,
+  item?: NetiPlotNodeDefinition
+        | NetiPlotEdgeDefinition
+        | NetiPlotShapeDefinition
+        | NetiPlotNodeDefinition[]
+        | NetiPlotShapeDefinition[]
+        | null,
+  event?: MouseEvent,
+) => void
+```
+
+## Event types — `NetiPlotMouseEventType`
+
+| Type | `item` value | Description |
+|------|-------------|-------------|
+| `'nodeClick'` | `NetiPlotNodeDefinition` | Single click on a node |
+| `'nodeDblClick'` | `NetiPlotNodeDefinition` | Double-click on a node |
+| `'nodesDragged'` | `NetiPlotNodeDefinition[]` | One or more nodes dragged |
+| `'edgeClick'` | `NetiPlotEdgeDefinition` | Single click on an edge |
+| `'edgeDblClick'` | `NetiPlotEdgeDefinition` | Double-click on an edge |
+| `'shapeClick'` | `NetiPlotShapeDefinition` | Click on a background shape |
+| `'shapeDblClick'` | `NetiPlotShapeDefinition` | Double-click on a background shape |
+| `'shapeUpdate'` | `NetiPlotShapeDefinition` | Shape moved or resized |
+| `'backgroundClick'` | `null` | Click on empty canvas area |
+
+## Example
+
+```ts
+onMouse={(type, item) => {
+  if (type === 'nodeClick') {
+    const node = item as NetiPlotNodeDefinition
+    console.log('Clicked node:', node.id, node.label)
+  }
+  if (type === 'backgroundClick') {
+    clearSelection()
+  }
+}}
+```
+
+## Drag interaction
+
+Drag is enabled by default. Disable it via `options.interaction`:
+
+```ts
+options={{ interaction: { allowGraphInteraction: false } }}
+```

--- a/docs/api/graph.md
+++ b/docs/api/graph.md
@@ -1,0 +1,76 @@
+# Graph Data
+
+The `graph` prop accepts a `NetiPlotGraph` object containing arrays of nodes and edges.
+
+```ts
+const graph: NetiPlotGraph = {
+  nodes: [...],
+  edges: [...],
+}
+```
+
+## Node definition — `NetiPlotNodeDefinition`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | ✓ | Unique identifier |
+| `label` | `string` | | Text label rendered below the node |
+| `innerLabel` | `string` | | Short text rendered inside the node circle |
+| `shape` | `string` | | Node shape: `'circle'` (default), `'square'`, `'image'` |
+| `size` | `number` | | Override `defaultSize` for this node |
+| `image` | `string` | | Key into the `images` map |
+| `type` | `string` | | Arbitrary type string, available in drawing functions |
+| `fixed` | `boolean` | | Exclude this node from layout calculations |
+| `x` | `number` | | Initial x position |
+| `y` | `number` | | Initial y position |
+| `style` | `NodeStyle` | | Visual overrides (see below) |
+| `[key: string]` | `any` | | Any extra field — available in `nodeDrawingFunction` |
+
+### Node style
+
+```ts
+style?: {
+  background?: string   // fill colour
+  border?: string       // stroke colour
+  size?: number         // size override (same as top-level size)
+  [key: string]: any    // additional fields for custom drawing
+}
+```
+
+## Edge definition — `NetiPlotEdgeDefinition`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | ✓ | Unique identifier |
+| `from` | `string` | ✓ | Source node ID |
+| `to` | `string` | ✓ | Target node ID |
+| `label` | `string` | | Text label rendered on the edge |
+| `size` | `number` | | Line width override |
+| `style` | `NetiPlotEdgeStyle` | | Visual overrides (see below) |
+
+### Edge style
+
+```ts
+style?: {
+  color?: string       // line colour
+  lineWidth?: number   // line width in pixels
+  font?: string        // label font string
+  fontColor?: string   // label font colour
+}
+```
+
+## Example
+
+```ts
+const graph: NetiPlotGraph = {
+  nodes: [
+    { id: 'web',  label: 'Web App',  style: { background: '#3b82f6' } },
+    { id: 'api',  label: 'API',      style: { background: '#8b5cf6' } },
+    { id: 'db',   label: 'Database', style: { background: '#10b981' } },
+  ],
+  edges: [
+    { id: 'e1', from: 'web', to: 'api' },
+    { id: 'e2', from: 'api', to: 'db',  style: { color: '#ef4444' } },
+  ],
+}
+```

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -1,0 +1,75 @@
+# Options — `NetiPlotOptions`
+
+The `options` prop accepts a nested configuration object. All fields are optional.
+
+```ts
+<NetiPlotReact
+  graph={graph}
+  options={{
+    nodes: { showLabels: true, defaultSize: 24 },
+    edges: { arrowheads: true },
+    layoutOptions: { fitOnUpdate: true },
+  }}
+/>
+```
+
+## `nodes` — `NetiPlotNodeOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `showLabels` | `boolean` | `true` | Show node labels |
+| `defaultSize` | `number` | `20` | Default node radius in pixels |
+| `nodeFillStyle` | `string` | | Default fill colour for nodes |
+| `scaleCompensation` | `false` | | Disable size scaling with zoom |
+
+## `edges` — `NetiPlotEdgeOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `showLabels` | `boolean` | `false` | Show edge labels |
+| `arrowheads` | `boolean` | `false` | Render arrowheads on edges |
+| `lineStyle` | `string` | `'solid'` | `'solid'` or `'dashed'` |
+
+## `cameraOptions` — `NetiPlotCameraOptions`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fitAllPadding` | `{ horizontal: number; vertical: number }` | Padding applied when fitting all nodes into view |
+
+## `layoutOptions` — `NetiPlotLayoutOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `fitOnUpdate` | `boolean` | `false` | Zoom to fit after each layout run |
+
+Additional keys are passed through to custom layouter functions.
+
+## `hover` — `NetiPlotHoverOptions`
+
+Tooltip shown when hovering a node or edge (React renderer).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `nodeRenderer` | `(node) => ReactNode \| null` | | Render tooltip content for a node |
+| `edgeRenderer` | `(edge) => ReactNode \| null` | | Render tooltip content for an edge |
+| `delay` | `number` | `750` | Milliseconds before tooltip appears |
+| `width` | `number` | `200` | Tooltip width in px (used for positioning) |
+| `height` | `number` | `150` | Tooltip height in px (used for positioning) |
+
+```ts
+hover: {
+  nodeRenderer: (node) => <div><strong>{node.label}</strong></div>,
+  delay: 400,
+}
+```
+
+## `interaction` — `NetiPlotInteractionOptions`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allowGraphInteraction` | `boolean` | `true` | Allow dragging nodes |
+| `allowShapeInteraction` | `boolean` | `false` | Allow selecting and resizing background shapes |
+
+## `showMutedOverlay` — `boolean`
+
+When `true`, renders a semi-transparent overlay behind the edit layer.

--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -1,0 +1,88 @@
+# Props — `<NetiPlotReact>`
+
+All props accepted by the `NetiPlotReact` component (`NetiPlotProps` in `types.ts`).
+
+## Required
+
+### `graph` — `NetiPlotGraph`
+
+The graph data to render. See [Graph data](/docs/api/graph) for the full type.
+
+```ts
+graph={{ nodes: [...], edges: [...] }}
+```
+
+## Display
+
+### `options` — `NetiPlotOptions`
+
+Nested configuration object. See [Options](/docs/api/options).
+
+### `shapes` — `NetiPlotShapeDefinition[]`
+
+Background shapes rendered behind the graph. See [Background shapes](/docs/shapes).
+
+### `className` — `string`
+
+CSS class name applied to the outermost container div.
+
+### `customControls` — `((data: CustomControlsData) => ReactNode) | null`
+
+Replace the built-in zoom controls with a custom renderer. Pass `null` to hide controls entirely.
+
+```ts
+customControls={({ zoomIn, zoomOut, fitAll }) => (
+  <button onClick={fitAll}>Fit</button>
+)}
+```
+
+## Interaction
+
+### `onMouse` — `NetiPlotMouseHandler`
+
+Mouse event callback. See [Mouse events](/docs/api/events).
+
+### `nodeDrawingFunction` — `NodeDrawingFunction`
+
+Custom canvas draw function called for every node. See [Custom drawing](/docs/custom-drawing).
+
+### `shapeDrawingFunction` — `ShapeDrawingFunction`
+
+Custom canvas draw function called for every background shape.
+
+### `images` — `NetiPlotImageMap`
+
+Map of image IDs to `HTMLImageElement`, `SVGImageElement`, `HTMLCanvasElement`, or an object with `{ element, scale?, offsetX?, offsetY? }`.
+
+```ts
+const img = new Image()
+img.src = '/icon.png'
+images={{ myIcon: img }}
+// then on node: { id: 'n1', image: 'myIcon' }
+```
+
+## Layout
+
+### `layouter` — `NetiPlotLayouter`
+
+Custom layout algorithm function. Defaults to built-in hierarchical layout. See [Custom layouts](/docs/custom-layouts).
+
+### `shouldRunLayouter` — `ShouldRunLayouter`
+
+Predicate called when graph data changes. Return `true` to re-run the layout.
+
+```ts
+shouldRunLayouter={(prev, next) =>
+  prev.graph.nodes.length !== next.graph.nodes.length
+}
+```
+
+## Programmatic access
+
+### `callbackFn` — `(data: NetiPlotCallbackData) => void`
+
+Called after mount. Provides imperative access to the network. See [Programmatic access](/docs/api/callback).
+
+### `identifier` — `string`
+
+Stable string ID for this instance. Useful when multiple graphs are rendered on the same page.

--- a/docs/custom-drawing.md
+++ b/docs/custom-drawing.md
@@ -1,0 +1,68 @@
+# Custom Node Drawing
+
+Override the default node renderer with a canvas drawing function via the `nodeDrawingFunction` prop.
+
+## Signature — `NodeDrawingFunction`
+
+```ts
+type NodeDrawingFunction = (
+  ctx: CanvasRenderingContext2D,
+  node: NetiPlotNodeDefinition,
+) => void
+```
+
+The context is already translated to the node centre — `(0, 0)` is the middle of the node. The context is also scaled for the current device pixel ratio.
+
+## Example
+
+```ts
+const nodeDrawingFunction: NodeDrawingFunction = (ctx, node) => {
+  const size = node.size ?? 20
+  const color = node.style?.background ?? '#4a90e2'
+
+  // Draw circle
+  ctx.beginPath()
+  ctx.arc(0, 0, size, 0, Math.PI * 2)
+  ctx.fillStyle = color
+  ctx.fill()
+
+  // Draw label
+  if (node.label) {
+    ctx.fillStyle = '#fff'
+    ctx.font = `bold ${size * 0.6}px sans-serif`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(node.label, 0, 0)
+  }
+}
+```
+
+## Custom node properties
+
+Any extra field on a node definition is passed through to the drawing function:
+
+```ts
+// Define nodes with custom fields
+{ id: 'a', label: 'Alert', severity: 'high', count: 3 }
+
+// Access in the drawing function
+const nodeDrawingFunction: NodeDrawingFunction = (ctx, node) => {
+  if (node.severity === 'high') {
+    ctx.fillStyle = '#ef4444'
+  }
+  // draw badge using node.count
+}
+```
+
+## Custom shape drawing — `ShapeDrawingFunction`
+
+Background shapes use the same pattern via `shapeDrawingFunction`:
+
+```ts
+type ShapeDrawingFunction = (
+  ctx: CanvasRenderingContext2D,
+  shape: NetiPlotShapeDefinition,
+) => void
+```
+
+The context origin is at the shape's `(x, y)` position. Width and height are available on the shape definition.

--- a/docs/custom-layouts.md
+++ b/docs/custom-layouts.md
@@ -1,0 +1,82 @@
+# Custom Layouts
+
+Replace the default hierarchical layout with any algorithm via the `layouter` prop.
+
+## Signature — `NetiPlotLayouter`
+
+```ts
+type NetiPlotLayouter = (
+  data: {
+    nodeMap: Map<string, NetiPlotNode>
+    edgeMap: Map<string, NetiPlotEdge>
+    shapes?: NetiPlotShapeDefinition[]
+  },
+  options: NetiPlotLayoutOptions,
+  screen: NetiPlotScreen,
+  onStopped?: () => void,
+) => NetiPlotLayouterResult
+```
+
+Set `node.destination = { x, y }` to animate nodes to their target positions. Set `node.x` and `node.y` directly for immediate placement.
+
+Call `onStopped?.()` when the layout is complete — this triggers a fit-to-view if `layoutOptions.fitOnUpdate` is enabled.
+
+## Synchronous layout
+
+```ts
+import type { NetiPlotLayouter } from '@jonmodell/netiplot'
+
+const circleLayout: NetiPlotLayouter = (data, options, screen, onStopped) => {
+  const nodes = Array.from(data.nodeMap.values())
+  const cx = (screen.width ?? 600) / 2
+  const cy = (screen.height ?? 400) / 2
+  const radius = Math.min(cx, cy) * 0.7
+
+  nodes.forEach((node, i) => {
+    const angle = (i / nodes.length) * Math.PI * 2
+    node.destination = {
+      x: cx + Math.cos(angle) * radius,
+      y: cy + Math.sin(angle) * radius,
+    }
+  })
+
+  onStopped?.()
+}
+```
+
+## Async / force layout
+
+Return `{ stop }` for layouts that run over multiple frames (e.g. force simulations):
+
+```ts
+const forceLayout: NetiPlotLayouter = (data, options, screen, onStopped) => {
+  const simulation = d3.forceSimulation(/* ... */)
+
+  simulation.on('end', () => onStopped?.())
+
+  return {
+    stop: () => simulation.stop(),
+  }
+}
+```
+
+## Controlling when layout re-runs — `ShouldRunLayouter`
+
+By default the layout re-runs whenever the graph changes. Override this with `shouldRunLayouter`:
+
+```ts
+// Only re-layout when the number of nodes changes
+const shouldRunLayouter: ShouldRunLayouter = (prev, next) =>
+  prev.graph.nodes.length !== next.graph.nodes.length
+```
+
+## `NetiPlotScreen`
+
+```ts
+interface NetiPlotScreen {
+  width: number | undefined
+  height: number | undefined
+  ratio: number
+  boundingRect: DOMRect | undefined | null
+}
+```

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,68 @@
+# Images & Icons
+
+Display images inside nodes using the `images` prop and the `image` field on node definitions.
+
+## Passing images
+
+```ts
+const serverIcon = new Image()
+serverIcon.src = '/icons/server.svg'
+
+<NetiPlotReact
+  graph={graph}
+  images={{ server: serverIcon }}
+/>
+```
+
+## Using an image on a node
+
+```ts
+{ id: 'n1', label: 'Web Server', shape: 'image', image: 'server' }
+```
+
+Setting `shape: 'image'` removes the default circle background, rendering only the image. Omit it to render the image on top of the default node circle.
+
+## Image definition — `NetiPlotImageDefinition`
+
+Images can be passed as a raw element or with positioning options:
+
+```ts
+// Raw element
+images={{ logo: imgElement }}
+
+// With scale and offset
+images={{
+  logo: {
+    element: imgElement,
+    scale: 0.8,       // scale relative to node size (default 1.0)
+    offsetX: 0,       // horizontal offset in pixels
+    offsetY: -2,      // vertical offset in pixels
+  }
+}}
+```
+
+Accepted element types: `HTMLImageElement`, `SVGImageElement`, `HTMLCanvasElement`.
+
+## Pre-loading images
+
+Images must be loaded before they can render. Use the `onload` event or a Promise:
+
+```ts
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = reject
+    img.src = src
+  })
+}
+
+// In a component:
+const [images, setImages] = useState<NetiPlotImageMap>({})
+
+useEffect(() => {
+  loadImage('/icons/server.svg').then((img) => {
+    setImages({ server: img })
+  })
+}, [])
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,32 @@
+# Installation
+
+```bash
+npm install @jonmodell/netiplot
+```
+
+## Entry points
+
+```ts
+import { NetiPlotReact } from '@jonmodell/netiplot'           // React component
+import { NetiPlot } from '@jonmodell/netiplot/vanilla'        // Vanilla JS class
+```
+
+No stylesheet import is required — styles are injected automatically at runtime.
+
+## Container setup
+
+`<NetiPlotReact>` renders absolutely-positioned canvases that fill their containing block. The wrapping element must have `position: relative`, a non-zero computed height, and `overflow: hidden`.
+
+```tsx
+{/* Fixed height */}
+<div style={{ position: 'relative', width: '100%', height: '600px', overflow: 'hidden' }}>
+  <NetiPlotReact graph={graph} />
+</div>
+
+{/* Flex-fill — parent must be a flex column with a defined height */}
+<div className="flex-1 relative overflow-hidden">
+  <NetiPlotReact graph={graph} />
+</div>
+```
+
+Do **not** add an extra `absolute inset-0` wrapper — the component already fills its container.

--- a/docs/react.md
+++ b/docs/react.md
@@ -1,0 +1,60 @@
+# React Component
+
+`<NetiPlotReact>` is a React component that renders a network graph on layered HTML5 canvases. It is driven entirely by props and re-renders via `useSyncExternalStore`.
+
+## Minimal example
+
+```tsx
+import { NetiPlotReact } from '@jonmodell/netiplot'
+import type { NetiPlotGraph } from '@jonmodell/netiplot'
+
+const graph: NetiPlotGraph = {
+  nodes: [
+    { id: 'a', label: 'Alpha' },
+    { id: 'b', label: 'Beta' },
+  ],
+  edges: [{ id: 'e1', from: 'a', to: 'b' }],
+}
+
+export default function MyGraph() {
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '600px', overflow: 'hidden' }}>
+      <NetiPlotReact graph={graph} />
+    </div>
+  )
+}
+```
+
+## Key props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `graph` | `NetiPlotGraph` | ✓ | Nodes and edges to render |
+| `options` | `NetiPlotOptions` | | Display and behaviour configuration |
+| `shapes` | `NetiPlotShapeDefinition[]` | | Background shapes drawn behind the graph |
+| `onMouse` | `NetiPlotMouseHandler` | | Click, drag, and hover events |
+| `layouter` | `NetiPlotLayouter` | | Custom layout algorithm (default: hierarchical) |
+| `shouldRunLayouter` | `ShouldRunLayouter` | | Predicate controlling when layout re-runs |
+| `callbackFn` | `(data: NetiPlotCallbackData) => void` | | Programmatic access (fit, camera, positions) |
+| `nodeDrawingFunction` | `NodeDrawingFunction` | | Custom canvas draw function per node |
+| `shapeDrawingFunction` | `ShapeDrawingFunction` | | Custom canvas draw function per shape |
+| `images` | `NetiPlotImageMap` | | Image map for node icons |
+| `customControls` | `(data) => ReactNode \| null` | | Replace or hide zoom controls |
+| `identifier` | `string` | | Stable instance ID |
+| `className` | `string` | | CSS class on the container div |
+
+See the [Props reference](/docs/api/props) for full type details.
+
+## Updating the graph
+
+Pass a new `graph` object to trigger a re-render. The engine diffs the incoming data and only updates changed nodes and edges.
+
+```tsx
+const [graph, setGraph] = useState(initialGraph)
+
+// Add a node
+setGraph(prev => ({
+  ...prev,
+  nodes: [...prev.nodes, { id: 'new', label: 'New node' }],
+}))
+```

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1,0 +1,72 @@
+# Background Shapes
+
+Background shapes are decorative or structural elements rendered behind the graph. Pass them via the `shapes` prop.
+
+## Shape definition — `NetiPlotShapeDefinition`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | `string` | | Unique identifier |
+| `shape` | `string` | ✓ | Shape type: `'rect'`, `'circle'`, `'ellipse'`, `'image'`, or custom |
+| `x` | `number` | ✓ | Left edge position in graph coordinates |
+| `y` | `number` | ✓ | Top edge position in graph coordinates |
+| `width` | `number` | | Width in graph coordinates |
+| `height` | `number` | | Height in graph coordinates |
+| `size` | `number` | | Shorthand for square shapes (sets both width and height) |
+| `style` | `NetiPlotShapeStyle` | | Visual properties |
+| `visible` | `boolean` | | Hide without removing (default `true`) |
+| `noEdit` | `boolean` | | Prevent resize/move handles |
+| `noClick` | `boolean` | | Suppress click events |
+| `boundsIgnore` | `boolean` | | Exclude from fit-to-view bounds calculation |
+
+### Shape style — `NetiPlotShapeStyle`
+
+```ts
+style?: {
+  background?: string                        // fill colour
+  border?: string | CanvasGradient          // stroke colour (alias: stroke, line)
+  lineWidth?: number                         // stroke width in pixels
+  fillColor?: string                         // alias for background (alias: fill)
+  strokeColor?: string                       // alias for border
+}
+```
+
+## Example
+
+```ts
+const shapes: NetiPlotShapeDefinition[] = [
+  {
+    id: 'region-a',
+    shape: 'rect',
+    x: 50, y: 50,
+    width: 300, height: 200,
+    style: {
+      background: 'rgba(59, 130, 246, 0.1)',
+      border: '#3b82f6',
+      lineWidth: 1,
+    },
+  },
+  {
+    id: 'zone',
+    shape: 'circle',
+    x: 400, y: 200,
+    size: 120,
+    style: { background: 'rgba(16, 185, 129, 0.15)' },
+    noEdit: true,
+  },
+]
+```
+
+## Shape interaction
+
+Enable shape editing (drag to move, handles to resize) via options:
+
+```ts
+options={{ interaction: { allowShapeInteraction: true } }}
+```
+
+Shape move and resize events fire as `'shapeUpdate'` on the `onMouse` callback.
+
+## Custom shape drawing
+
+Use `shapeDrawingFunction` to fully control how a shape is rendered. See [Custom drawing](/docs/custom-drawing).

--- a/docs/vanilla.md
+++ b/docs/vanilla.md
@@ -1,0 +1,72 @@
+# Vanilla JS Class
+
+`NetiPlot` is a framework-agnostic class that manages its own DOM structure. Use it in any environment without React.
+
+## Basic usage
+
+```ts
+import { NetiPlot } from '@jonmodell/netiplot/vanilla'
+
+const container = document.getElementById('network')
+
+const net = new NetiPlot(container, {
+  graph: {
+    nodes: [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+    ],
+    edges: [{ id: 'e1', from: 'a', to: 'b' }],
+  },
+  options: {
+    nodes: { showLabels: true },
+    edges: { arrowheads: true },
+  },
+})
+```
+
+The container must have an explicit width and height. `position: relative` is set automatically if not already applied.
+
+## Instance methods
+
+| Method | Description |
+|--------|-------------|
+| `setGraph(graph, shapes?)` | Replace graph data. Triggers layout if nodes/edges changed. |
+| `setOptions(options)` | Update options. |
+| `zoom(level)` | `'in' \| 'out' \| 'all' \| 'selection'` |
+| `fit()` | Zoom to fit all nodes. |
+| `getCamera()` | Returns current `PanScaleState`. |
+| `getNodePositions()` | Returns `Record<id, { x, y }>`. |
+| `destroy()` | Removes all DOM elements and cleans up event listeners. |
+
+## Hover tooltips
+
+The vanilla class uses a callback-based hover API (no React):
+
+```ts
+const net = new NetiPlot(container, {
+  graph,
+  hover: {
+    nodeRenderer: (node) => `<strong>${node.label}</strong>`,  // HTML string or HTMLElement
+    edgeRenderer: (edge) => `Edge: ${edge.id}`,
+    delay: 500,
+  },
+})
+```
+
+The tooltip `div` has class `netiplot-tooltip` — style it however you like.
+
+## Constructor config
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `graph` | `NetiPlotGraph` | Required. Nodes and edges. |
+| `options` | `NetiPlotOptions` | Display and behaviour options. |
+| `shapes` | `NetiPlotShapeDefinition[]` | Background shapes. |
+| `layouter` | `NetiPlotLayouter` | Custom layout algorithm. |
+| `shouldRunLayouter` | `ShouldRunLayouter` | Predicate for layout re-runs. |
+| `onMouse` | `NetiPlotMouseHandler` | Mouse event callback. |
+| `nodeDrawingFunction` | `NodeDrawingFunction` | Custom canvas draw per node. |
+| `shapeDrawingFunction` | `ShapeDrawingFunction` | Custom canvas draw per shape. |
+| `images` | `NetiPlotImageMap` | Image map for node icons. |
+| `identifier` | `string` | Stable instance ID. |
+| `hover` | `NetiPlotHoverConfig` | Tooltip configuration. |


### PR DESCRIPTION
Adds docs/ with Markdown files covering the full public API, derived directly from types.ts. Intended as LLM-readable source of truth and the basis for the netiplot-site documentation pages.

- docs/installation.md — container setup, entry points
- docs/react.md — NetiPlotReact component quickstart and prop summary
- docs/vanilla.md — NetiPlot class API and constructor config
- docs/api/props.md — full NetiPlotProps reference
- docs/api/options.md — NetiPlotOptions structure
- docs/api/graph.md — NetiPlotGraph, node and edge definitions
- docs/api/events.md — mouse event types and onMouse handler
- docs/api/callback.md — callbackFn / programmatic access
- docs/custom-drawing.md — NodeDrawingFunction and ShapeDrawingFunction
- docs/custom-layouts.md — NetiPlotLayouter interface and examples
- docs/shapes.md — NetiPlotShapeDefinition reference
- docs/images.md — NetiPlotImageMap and image loading patterns